### PR TITLE
fix webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.html
+++ b/index.html
@@ -14,6 +14,6 @@
     </style>
   </head>
   <body>
-    <script src="bundle.js"></script>
+    <script src="build/bundle.js"></script>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,12 @@
 const path = require('path');
 
 module.exports = {
-  entry: path.join(__dirname, "src/main"),
+  entry: {
+    'build/bundle': path.join(__dirname, "src/main"),
+  },
   output: {
-    path: path.join(__dirname, "build"),
-    filename: "bundle.js"
+    path: __dirname,
+    filename: "[name].js"
   },
   module: {
     loaders: [


### PR DESCRIPTION
This tells `index.html` to look for `build/bundle.js` instead of `bundle.js` and then updates the webpack target to call the build target `build/bundle`